### PR TITLE
fix: upgrade trunk to version 0.18.1 / enable githooks

### DIFF
--- a/.trunk/.gitignore
+++ b/.trunk/.gitignore
@@ -1,3 +1,7 @@
 *out
 *logs
-external
+*actions
+*notifications
+plugins
+user_trunk.yaml
+user.yaml

--- a/.trunk/config/.hadolint.yaml
+++ b/.trunk/config/.hadolint.yaml
@@ -1,0 +1,4 @@
+# Following source doesn't work in most setups
+ignored:
+  - SC1090
+  - SC1091

--- a/.trunk/config/svgo.config.js
+++ b/.trunk/config/svgo.config.js
@@ -1,0 +1,14 @@
+module.exports = {
+  plugins: [
+    {
+      name: "preset-default",
+      params: {
+        overrides: {
+          removeViewBox: false, // https://github.com/svg/svgo/issues/1128
+          sortAttrs: true,
+          removeOffCanvasPaths: true,
+        },
+      },
+    },
+  ],
+};

--- a/.trunk/logs
+++ b/.trunk/logs
@@ -1,1 +1,0 @@
-/home/eli/.cache/trunk/repos/74f97634c4aefb6b67da2963e994ea18/logs

--- a/.trunk/logs
+++ b/.trunk/logs
@@ -1,1 +1,1 @@
-/Users/shivanshvij/.cache/trunk/repos/48c9c5d3298f6198ad85aaa16535615b/logs
+/home/eli/.cache/trunk/repos/74f97634c4aefb6b67da2963e994ea18/logs

--- a/.trunk/out
+++ b/.trunk/out
@@ -1,1 +1,0 @@
-/home/eli/.cache/trunk/repos/74f97634c4aefb6b67da2963e994ea18/out

--- a/.trunk/out
+++ b/.trunk/out
@@ -1,1 +1,1 @@
-/Users/shivanshvij/.cache/trunk/repos/48c9c5d3298f6198ad85aaa16535615b/out
+/home/eli/.cache/trunk/repos/74f97634c4aefb6b67da2963e994ea18/out

--- a/.trunk/plugins/trunk
+++ b/.trunk/plugins/trunk
@@ -1,1 +1,0 @@
-/home/eli/.cache/trunk/plugins/https---github-com-trunk-io-plugins/v0.0.5

--- a/.trunk/plugins/trunk
+++ b/.trunk/plugins/trunk
@@ -1,1 +1,1 @@
-/Users/shivanshvij/.cache/trunk/plugins/https---github-com-trunk-io-plugins/v0.0.3
+/home/eli/.cache/trunk/plugins/https---github-com-trunk-io-plugins/v0.0.5

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,14 +1,30 @@
 version: 0.1
+runtimes:
+  enabled:
+    - go@1.18.3
+    - node@16.14.2
+plugins:
+  sources:
+    - id: trunk
+      ref: v0.0.5
+      uri: https://github.com/trunk-io/plugins
+actions:
+  enabled:
+    - trunk-cache-prune
+    - trunk-upgrade-available
 cli:
-  version: 0.16.1-beta
+  version: 0.18.1-beta
 lint:
   enabled:
-    - actionlint@1.6.13
-    - gitleaks@8.8.7
+    - git-diff-check
+    - hadolint@2.10.0
+    - svgo@2.8.0
+    - actionlint@1.6.21
+    - gitleaks@8.15.0
     - gofmt@1.18.3
-    - golangci-lint@1.46.2
-    - markdownlint@0.31.1
-    - prettier@2.6.2
+    - golangci-lint@1.50.0
+    - markdownlint@0.32.2
+    - prettier@2.7.1
   ignore:
     - linters: [ALL]
       paths:

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -1,13 +1,15 @@
 version: 0.1
-runtimes:
-  enabled:
-    - go@1.18.3
-    - node@16.14.2
+cli:
+  version: 0.18.1-beta
 plugins:
   sources:
     - id: trunk
       ref: v0.0.5
       uri: https://github.com/trunk-io/plugins
+runtimes:
+  enabled:
+    - go@1.18.3
+    - node@16.14.2
 actions:
   enabled:
     - trunk-announce
@@ -15,8 +17,6 @@ actions:
     - trunk-fmt-pre-commit
     - trunk-cache-prune
     - trunk-upgrade-available
-cli:
-  version: 0.18.1-beta
 lint:
   enabled:
     - git-diff-check

--- a/.trunk/trunk.yaml
+++ b/.trunk/trunk.yaml
@@ -10,6 +10,9 @@ plugins:
       uri: https://github.com/trunk-io/plugins
 actions:
   enabled:
+    - trunk-announce
+    - trunk-check-pre-push
+    - trunk-fmt-pre-commit
     - trunk-cache-prune
     - trunk-upgrade-available
 cli:


### PR DESCRIPTION
## Description

- trunk tooling was 2 release versions behind
- enabled new linters for SVG files optimization / catch git conflict markers
- automatically run `trunk fmt` on git commit and `trunk check` on git push

Fixes # (issue)

## Type of change

**Please update the title of this PR to reflect the type of change.** (Delete the ones that aren't required).

- [X] Bug fix (non-breaking change which fixes an issue) [title: 'fix:']

## Testing

Good

## Linting

It's now run automatically!

- [X] `trunk check` has been run

## Final Checklist:

- [X] My code follows the style guidelines of this project
- [X] I have performed a self-review of my own code

Signed-off-by: Eli Schleifer <elischleifer@outlook.com>
