### PR TITLE
[Docs] Use new gradient color syntax

### DIFF
--- a/docs/mint.json
+++ b/docs/mint.json
@@ -11,7 +11,9 @@
     "dark": "#9015D9",
     "ultraLight": "#F8EEFE",
     "ultraDark": "#6A06A5",
-    "backgroundDark": "#121212"
+    "background": {
+      "dark": "#121212"
+    }
   },
   "topbarCtaButton": {
     "type": "github",

--- a/docs/mint.json
+++ b/docs/mint.json
@@ -10,7 +10,8 @@
     "light": "#C854FF",
     "dark": "#9015D9",
     "ultraLight": "#F8EEFE",
-    "ultraDark": "#6A06A5"
+    "ultraDark": "#6A06A5",
+    "backgroundDark": "#121212"
   },
   "topbarCtaButton": {
     "type": "github",
@@ -20,12 +21,20 @@
     {
       "name": "Discord",
       "icon": "discord",
-      "url": "https://loopholelabs.io/discord"
+      "url": "https://loopholelabs.io/discord",
+      "color": {
+        "from": "#7c34ff",
+        "to": "#fe9195"
+      }
     },
     {
       "name": "GitHub",
       "icon": "github",
-      "url": "https://github.com/loopholelabs/frpc-go"
+      "url": "https://github.com/loopholelabs/frpc-go",
+      "color": {
+        "from": "#7c34ff",
+        "to": "#fe9195"
+      }
     }
   ],
   "navigation": [
@@ -63,11 +72,6 @@
   "footerSocials": {
     "discord": "https://loopholelabs.io/discord",
     "github": "https://github.com/loopholelabs/frpc-go"
-  },
-  "classes": {
-    "anchors": "group-hover:bg-gradient-to-tr from-[#7c34ff] to-[#fe9195]",
-    "activeAnchors": "bg-gradient-to-tr",
-    "navigationItem": "duration-100"
   },
   "backgroundImage": "/images/lightbackground.png",
   "analytics": {


### PR DESCRIPTION
## Description

Mintlify has launched a major update that reduces page load times by 88%.

The new update does not support custom Tailwind classes. This PR updates your docs to use the new gradient color syntax instead of setting them with Tailwind classes. The PR also sets a background colour in dark mode, we had #121212 as a default value before but users have to define it manually now.

**After merging this PR, your gradient anchors will temporarily default to a single colour. The gradient will return when we finish migrating your docs to the new infrastructure, 24 hours after this PR is merged.**

## Type of change

Updates documentation

## Testing

Tests should not be affected.

## Linting

Linting should not be affected.

## Final Checklist:

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] Any dependent changes have been merged and published in downstream modules
- [ ] I have checked my code and corrected any misspellings
