### PR TITLE
Fix: Non-Stream Proto Generation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
 
+## [v0.7.2] - 2022-12-10
+
+### Fixes
+
+- Fixed a bug where stream handlers would be generated for a proto file without streams
+
 ## [v0.7.1] - 2022-12-10
 
 ### Changes
@@ -47,7 +53,8 @@ to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 > Changelogs for [v0.5.0] and before can be found at https://github.com/loopholelabs/frisbee-go
 
-[unreleased]: https://github.com/loopholelabs/frpc-go/compare/v0.7.1...HEAD
+[unreleased]: https://github.com/loopholelabs/frpc-go/compare/v0.7.2...HEAD
+[v0.7.2]: https://github.com/loopholelabs/frpc-go/releases/tag/v0.7.2
 [v0.7.1]: https://github.com/loopholelabs/frpc-go/releases/tag/v0.7.1
 [v0.7.0]: https://github.com/loopholelabs/frpc-go/releases/tag/v0.7.0
 [v0.6.0]: https://github.com/loopholelabs/frpc-go/releases/tag/v0.6.0

--- a/templates/server.templ
+++ b/templates/server.templ
@@ -52,7 +52,7 @@ func NewServer({{ GetServerFields .services }}, tlsConfig *tls.Config, logger *z
         }
     }
 
-
+    {{ if .numStreamMethods -}}
     fsrv.SetStreamHandler(func(conn *frisbee.Async, stream *frisbee.Stream) {
         p, err := stream.ReadPacket()
         if err != nil {
@@ -79,6 +79,8 @@ func NewServer({{ GetServerFields .services }}, tlsConfig *tls.Config, logger *z
             {{end -}}
         }
     })
+
+    {{ end -}}
 
     fsrv.ConnContext = func (ctx context.Context, conn *frisbee.Async) context.Context {
         return context.WithValue(ctx, connectionContextKey, conn)


### PR DESCRIPTION
This PR fixes a bug where stream handlers would be generated for a proto file without streams. 