### PR TITLE
Fix typo, grammar and change wording in headline

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,8 +3,8 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Tests](https://github.com/loopholelabs/frpc-go/actions/workflows/tests.yaml/badge.svg)](https://github.com/loopholelabs/frpc-go/actions/workflows/tests.yaml)
 
-This is the [Go](http://golang.org) implementation of [fRPC](https://frpc.io), a high-performance RPC framework
-designed for performance and stability, and it uses the [frisbee-go](https://github.com/loopholelabs/frisbee-go) messaging framework under the hood.
+This is the [Go](http://golang.org) implementation of [fRPC](https://frpc.io), an RPC framework
+designed for high performance and stability, that uses the [frisbee-go](https://github.com/loopholelabs/frisbee-go) messaging framework under the hood.
 
 **This library requires Go1.18 or later.**
 

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Tests](https://github.com/loopholelabs/frpc-go/actions/workflows/tests.yaml/badge.svg)](https://github.com/loopholelabs/frpc-go/actions/workflows/tests.yaml)
 
-This is the [Go](http://golang.org) implementation of [fRPC](https://frpc.io), a high-performance RPC framework for
+This is the [Go](http://golang.org) implementation of [fRPC](https://frpc.io), a high-performance RPC framework
 designed for performance and stability, and it uses the [frisbee-go](https://github.com/loopholelabs/frisbee-go) messaging framework under the hood.
 
 **This library requires Go1.18 or later.**

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@
 [![License: Apache 2.0](https://img.shields.io/badge/License-Apache%202.0-brightgreen.svg)](https://www.apache.org/licenses/LICENSE-2.0)
 [![Tests](https://github.com/loopholelabs/frpc-go/actions/workflows/tests.yaml/badge.svg)](https://github.com/loopholelabs/frpc-go/actions/workflows/tests.yaml)
 
-This is the [Go](http://golang.org) implementation of [fRPC](https://frpc.io), an RPC framework
+This is the [Go](http://golang.org) implementation of [fRPC](https://frpc.io), a modern RPC framework
 designed for high performance and stability, that uses the [frisbee-go](https://github.com/loopholelabs/frisbee-go) messaging framework under the hood.
 
 **This library requires Go1.18 or later.**


### PR DESCRIPTION
## Description

Found a typo and some incorrect grammar in the headline while reading the documentation.
I replaced the wording a bit because it seemed a bit odd to have performance twice and just performance without 'high'.

## Type of change

Fixes typo, grammar and replaced duplicate `performance` with `modern` and just a single high performance.

Changes:

- This is the [Go](http://golang.org/) implementation of [fRPC](https://frpc.io/), a high-performance RPC framework for designed for performance and stability, and it uses the [frisbee-go](https://github.com/loopholelabs/frisbee-go) messaging framework under the hood.

to:
- This is the [Go](http://golang.org) implementation of [fRPC](https://frpc.io), a modern RPC framework
designed for high performance and stability, that uses the [frisbee-go](https://github.com/loopholelabs/frisbee-go) messaging framework under the hood.

Let me know if you prefer just a version with just the fixed grammar and typo or with another word instead of modern (next-gen, etc...) and I can change the PR.

@ShivanshVij 
