### PR TITLE
docs: fix typo - mention Rust instead of JS/TS under Rust Support

### DIFF
--- a/docs/getting-started/roadmap.mdx
+++ b/docs/getting-started/roadmap.mdx
@@ -56,7 +56,7 @@ deserialize RPCs in Typescript.
 
 Currently, fRPC is only compatible with `Golang` but we plan to add support for Rust in the near future.
 
-We've already begun the work required to add support for JS and TS by porting the [polyglot-go](https://github.com/loopholelabs/polyglot-go)
+We've already begun the work required to add support for Rust by porting the [polyglot-go](https://github.com/loopholelabs/polyglot-go)
 framework to [Rust](https://github.com/loopholelabs/polyglot-rs). This means we are already able to serialize and
 deserialize RPCs in Rust.
 


### PR DESCRIPTION
## Type of change

- [x] This change requires a documentation update
